### PR TITLE
[#8] 불러오기 기능을 사용하면 기존 항목이 ListBox에 남아있는 문제

### DIFF
--- a/SimplePacker/SimplePacker.cpp
+++ b/SimplePacker/SimplePacker.cpp
@@ -65,8 +65,9 @@ WCHAR* getFileNameFromDirectory(WCHAR* dir) {
     }
 
     DWORD len = dir + dirCnt - lastSlash - 1;
-    WCHAR* fileName = (WCHAR*)malloc(sizeof(WCHAR) * len + 1);
-    fileName[len] = L'\0';
+    DWORD nameSize = sizeof(WCHAR) * (len + 1);
+    WCHAR* fileName = (WCHAR*)malloc(nameSize);
+    ZeroMemory(fileName, nameSize);
 
     int lenCnt = 0;
     for (WCHAR* iter = lastSlash + 1; *iter != L'\0'; ++iter) {
@@ -142,6 +143,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
             case IDM_SAVEFILE:
                 return 0;
             case IDM_LOAD:
+                init();
                 if (_packedFileName != nullptr) {
                     CoTaskMemFree(_packedFileName);
                 }


### PR DESCRIPTION
 > 불러오기 버튼 누를 때도 init 함수 호출하도록 수정
 > 파일 경로에서 파일 이름만 얻어내는 과정에서 메모리 할당이 의도대로 진행되지 않는 부분 수정